### PR TITLE
Develop v0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ MIDSV (Match, Insertion, Deletion, Substitution, and inVersion) is a comma-separ
 > MIDSV is intended for targeted amplicon sequences (10-100 kbp).  
 > Using whole chromosomes as references may exhaust memory and crash.  
 
+
+>[!IMPORTANT]
+> MIDSV requires long-format cstag tags in the SAM file.  
+> Please use minimap2 with `--cs=long` option.
+> or use [`cstag`](https://github.com/akikuno/cstag) tool to append long-format cstag.
+
 The output includes `MIDSV` and, optionally, `QSCORE`.
 
 - `MIDSV` preserves original nucleotides while annotating mutations.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,19 @@ midsv.io.read_jsonl(path_input: str | Path) -> Iterator[dict[str, str]]
 
 Conversely, `midsv.io.read_jsonl` reads JSONL as an iterator of dictionaries.
 
+## Reverse complement MIDSV
+
+```python
+from midsv import formatter
+
+midsv_tag = "=A,=A,-G,+T|+C|=A,=A,*AG,=C"
+revcomp_tag = formatter.revcomp(midsv_tag)
+print(revcomp_tag)
+# =G,*TC,=T,=T,+G|+A|-C,=T,=T
+```
+
+`midsv.formatter.revcomp` returns the reverse complement of a MIDSV string. Insertions are reversed and complemented with their anchor moved to the new position, following the MIDSV specification.
+
 ## Export VCF
 
 ```python
@@ -224,4 +237,3 @@ write_vcf(alignments, "variants.vcf", large_sv_threshold=50)
 ```
 
 `midsv.io.write_vcf` writes MIDSV output to VCF and supports insertion, deletion, substitution, large insertion, large deletion, and inversion. Insertions longer than `large_sv_threshold` are emitted as symbolic `<INS>`, large deletions (or `=N` padding) use `<DEL>`, and inversions use `<INV>`. The INFO field includes `TYPE` or `SVTYPE`, `SVLEN`, `SEQ`, and `QNAME`.
-

--- a/README.md
+++ b/README.md
@@ -43,24 +43,8 @@ From [PyPI](https://pypi.org/project/midsv/):
 pip install midsv
 ```
 
-# 📘Usage
 
-```python
-midsv.transform(
-    path_sam: str | Path,
-    qscore: bool = False,
-    keep: str | list[str] = None
-) -> list[dict[str, str | int]]
-```
-
-- path_sam: Path to a SAM file on disk.
-- qscore (bool, optional): Output QSCORE. Defaults to False.
-- keep: Subset of {'FLAG', 'POS', 'SEQ', 'QUAL', 'CIGAR', 'CSTAG'} to include from the SAM file. Defaults to None.
-
-- `midsv.transform()` returns a list of dictionaries containing `QNAME`, `RNAME`, `MIDSV`, and optionally `QSCORE`, plus any fields specified by `keep`.
-- `MIDSV` and `QSCORE` are comma-separated strings and have the same reference sequence length.
-
-# 📜Specification
+# 📜Specifications
 
 ## MIDSV
 
@@ -87,42 +71,23 @@ midsv.transform(
 As with `MIDSV`, `QSCORE` uses `|` to separate quality scores in insertion sites.
 
 
-# 🧩Helper functions
 
-## Read SAM file
-
-```python
-midsv.io.read_sam(path_sam: str | Path) -> Iterator[list[str]]
-```
-
-`midsv.io.read_sam` reads a local SAM file into an iterator of string lists.
-
-
-## Read/Write JSON Line (JSONL)
+# 📘Usage
 
 ```python
-midsv.io.write_jsonl(dicts: list[dict[str, str]], path_output: str | Path)
+midsv.transform(
+    path_sam: str | Path,
+    qscore: bool = False,
+    keep: str | list[str] = None
+) -> list[dict[str, str | int]]
 ```
 
-Since `midsv.transform` returns a list of dictionaries, `midsv.io.write_jsonl` outputs it to a file in JSONL format.
+- path_sam: Path to a SAM file on disk.
+- qscore (bool, optional): Output QSCORE. Defaults to False.
+- keep: Subset of {'FLAG', 'POS', 'SEQ', 'QUAL', 'CIGAR', 'CSTAG'} to include from the SAM file. Defaults to None.
 
-```python
-midsv.io.read_jsonl(path_input: str | Path) -> Iterator[dict[str, str]]
-```
-
-Conversely, `midsv.io.read_jsonl` reads JSONL as an iterator of dictionaries.
-
-## Export VCF
-
-```python
-from midsv import transform
-from midsv.io import write_vcf
-
-alignments = transform("examples/example_indels.sam", qscore=False)
-write_vcf(alignments, "variants.vcf", large_sv_threshold=50)
-```
-
-`midsv.io.write_vcf` writes MIDSV output to VCF and supports insertion, deletion, substitution, large insertion, large deletion, and inversion. Insertions longer than `large_sv_threshold` are emitted as symbolic `<INS>`, large deletions (or `=N` padding) use `<DEL>`, and inversions use `<INV>`. The INFO field includes `TYPE` or `SVTYPE`, `SVLEN`, `SEQ`, and `QNAME`.
+- `midsv.transform()` returns a list of dictionaries containing `QNAME`, `RNAME`, `MIDSV`, and optionally `QSCORE`, plus any fields specified by `keep`.
+- `MIDSV` and `QSCORE` are comma-separated strings and have the same reference sequence length.
 
 
 # 🖍️Examples
@@ -220,3 +185,43 @@ print(midsv.transform(path_sam, qscore=True))
 # ]
 
 ```
+
+
+
+# 🧩Helper functions
+
+## Read SAM file
+
+```python
+midsv.io.read_sam(path_sam: str | Path) -> Iterator[list[str]]
+```
+
+`midsv.io.read_sam` reads a local SAM file into an iterator of string lists.
+
+
+## Read/Write JSON Line (JSONL)
+
+```python
+midsv.io.write_jsonl(dicts: list[dict[str, str]], path_output: str | Path)
+```
+
+Since `midsv.transform` returns a list of dictionaries, `midsv.io.write_jsonl` outputs it to a file in JSONL format.
+
+```python
+midsv.io.read_jsonl(path_input: str | Path) -> Iterator[dict[str, str]]
+```
+
+Conversely, `midsv.io.read_jsonl` reads JSONL as an iterator of dictionaries.
+
+## Export VCF
+
+```python
+from midsv import transform
+from midsv.io import write_vcf
+
+alignments = transform("examples/example_indels.sam", qscore=False)
+write_vcf(alignments, "variants.vcf", large_sv_threshold=50)
+```
+
+`midsv.io.write_vcf` writes MIDSV output to VCF and supports insertion, deletion, substitution, large insertion, large deletion, and inversion. Insertions longer than `large_sv_threshold` are emitted as symbolic `<INS>`, large deletions (or `=N` padding) use `<DEL>`, and inversions use `<INV>`. The INFO field includes `TYPE` or `SVTYPE`, `SVLEN`, `SEQ`, and `QNAME`.
+

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -12,15 +12,13 @@
 
 <!-- ############################################################# # -->
 
-# v0.13.0 (2025-12-06)
+# v0.13.1 (2026-01-07)
 
 ## 🌟 New Features
 
-- Add `midsv.io.write_vcf` to export MIDSV outputs as VCF supporting insertion, deletion, substitution, large insertion, large deletion, and inversion.
+- Add `midsv.formatter.revcomp` to generate the reverse complement of a MIDSV string, including insertions with anchors moved to the new position and proper handling of substitution tokens.
+- Add `END` to the INFO field for deletion records in `midsv.io.write_vcf` when `TYPE=DEL` or `SVTYPE=DEL`, computed from `POS` and `SVLEN` for clearer interval representation.
 
-## 📝 Documentation
-
-- Document VCF export usage and supported variant types in README.
 
 
 
@@ -33,6 +31,18 @@
 
 </details> -->
 
+<details>
+<summary> v0.13.0 (2025-12-06) </summary>
+
+## 🌟 New Features
+
+- Add `midsv.io.write_vcf` to export MIDSV outputs as VCF supporting insertion, deletion, substitution, large insertion, large deletion, and inversion.
+
+## 📝 Documentation
+
+- Document VCF export usage and supported variant types in README.
+
+</details>
 
 
 <details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "midsv"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python module to convert SAM to MIDSV format."
 authors = ["Akihiro Kuno <akuno@md.tsukuba.ac.jp>"]
 homepage = "https://github.com/akikuno/midsv"

--- a/src/midsv/io.py
+++ b/src/midsv/io.py
@@ -223,6 +223,18 @@ def write_vcf(alignments: list[dict[str, str | int]], path_output: str | Path, l
         f.write("##fileformat=VCFv4.3\n")
         f.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
         for record in records:
+            info = record.get("INFO", {})
+            if isinstance(info, dict) and "END" not in info:
+                svtype = info.get("SVTYPE") or info.get("TYPE")
+                if svtype == "DEL":
+                    svlen = info.get("SVLEN")
+                    if svlen is not None:
+                        try:
+                            svlen_int = int(svlen)
+                        except (TypeError, ValueError):
+                            svlen_int = None
+                        if svlen_int is not None:
+                            info["END"] = int(record["POS"]) + abs(svlen_int) - 1
             info_str = _format_info(record["INFO"])
             f.write(
                 f"{record['CHROM']}\t{record['POS']}\t.\t{record['REF']}\t{record['ALT']}\t.\tPASS\t{info_str}\n"

--- a/tests/test_formator.py
+++ b/tests/test_formator.py
@@ -182,3 +182,15 @@ def test_remove_resequence():
 )
 def test_alignments_to_dict(sam, expected):
     assert formatter.alignments_to_dict(sam) == expected
+
+
+def test_revcomp_basic():
+    midsv_tag = "=A,=C,=G,=T,=N"
+    expected = "=N,=A,=C,=G,=T"
+    assert formatter.revcomp(midsv_tag) == expected
+
+
+def test_revcomp_insertion_shift():
+    midsv_tag = "=A,=A,-G,+T|+C|=A,=A,*AG,=C"
+    expected = "=G,*TC,=T,=T,+G|+A|-C,=T,=T"
+    assert formatter.revcomp(midsv_tag) == expected

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -68,11 +68,11 @@ def test_write_vcf(tmp_path):
     expected = [
         "##fileformat=VCFv4.3",
         "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
-        "example\t3\t.\tN\t<DEL>\t.\tPASS\tTYPE=DEL;SVLEN=-6;SEQ=NNNNNN;QNAME=large-deletion",
+        "example\t3\t.\tN\t<DEL>\t.\tPASS\tTYPE=DEL;SVLEN=-6;SEQ=NNNNNN;QNAME=large-deletion;END=8",
         "example\t5\t.\tA\tG\t.\tPASS\tTYPE=SUB;QNAME=indel_sub",
         "example\t6\t.\tC\tCTTT\t.\tPASS\tTYPE=INS;SVLEN=3;SEQ=TTT;QNAME=indel_sub",
         "example\t6\t.\tC\t<INV>\t.\tPASS\tSVTYPE=INV;SVLEN=3;SEQ=CGT;QNAME=inversion",
-        "example\t7\t.\tA\t<DEL>\t.\tPASS\tTYPE=DEL;SVLEN=-2;SEQ=AA;QNAME=indel_sub",
+        "example\t7\t.\tA\t<DEL>\t.\tPASS\tTYPE=DEL;SVLEN=-2;SEQ=AA;QNAME=indel_sub;END=8",
         "longins\t1\t.\tG\t<INS>\t.\tPASS\tTYPE=INS;SVLEN=6;SEQ=AAAAAA;QNAME=long-ins",
     ]
     assert content == expected


### PR DESCRIPTION
# v0.13.1 (2026-01-07)

## 🌟 New Features

- Add `midsv.formatter.revcomp` to generate the reverse complement of a MIDSV string, including insertions with anchors moved to the new position and proper handling of substitution tokens.
- Add `END` to the INFO field for deletion records in `midsv.io.write_vcf` when `TYPE=DEL` or `SVTYPE=DEL`, computed from `POS` and `SVLEN` for clearer interval representation.

